### PR TITLE
fix(climate): derive hvac_action from operating_state, not operating_mode

### DIFF
--- a/custom_components/vivint/climate.py
+++ b/custom_components/vivint/climate.py
@@ -196,7 +196,7 @@ class VivintClimate(VivintEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
-        return VIVINT_HVAC_STATUS_MAP.get(self.device.operating_mode, HVACAction.IDLE)
+        return VIVINT_HVAC_STATUS_MAP.get(self.device.operating_state, HVACAction.IDLE)
 
     @property
     def fan_mode(self) -> str:


### PR DESCRIPTION
## Summary

`hvac_action` reads `self.device.operating_mode` where it should read `self.device.operating_state`. One word, but it silently disables equipment-state reporting for every thermostat user.

```python
# custom_components/vivint/climate.py:199
-        return VIVINT_HVAC_STATUS_MAP.get(self.device.operating_mode, HVACAction.IDLE)
+        return VIVINT_HVAC_STATUS_MAP.get(self.device.operating_state, HVACAction.IDLE)
```

`VIVINT_HVAC_STATUS_MAP` is keyed by `OperatingState`. `hvac_mode` on line 194 correctly uses `operating_mode` and is untouched.

## Why it fails silently

Both enums are `IntEnum` with colliding values:

| | 0 | 1 | 2 | 3 |
|---|---|---|---|---|
| `OperatingMode` | `OFF` | `HEAT` | `COOL` | `AUTO` |
| `OperatingState` | `IDLE` | `HEATING` | `COOLING` | — |

`dict.get()` hashes on the int, so `OperatingMode.COOL(2)` matches the `OperatingState.COOLING(2)` key. The lookup **succeeds against the wrong enum class** — no `KeyError`, no fallback to the default, nothing logged. A thermostat sitting in cool mode reports `hvac_action: cooling` permanently, whether or not the compressor is running. Modes with no colliding key (e.g. `AUTO=3`) fall through to `HVACAction.IDLE`.

`Thermostat.operating_state` already exists in vivintpy and is the value this map was written for. It is currently referenced nowhere in the integration.

## Evidence

Verified on a live system — 3× CT200X thermostats, vivintpy 2025.0.2, HA 2026.6.4.

**1. The bug predicts the recorded history exactly.** Over 30 days of recorder history one thermostat produced 2807 `cooling`, one `heating`, one `idle`. Its `hvac_mode` history over the same window: 2807 `cool`, one `heat`, one `heat_cool`. Under the collision, `cool(2)→cooling`, `heat(1)→heating`, `heat_cool/AUTO(3)→` no key `→` default `IDLE`. Every row is accounted for, including both one-off anomalies. There is no residual to explain.

**2. `operating_state` is live and correct.** Watching the raw PubNub stream (`pubnub` logger at debug), a full cooling cycle on one thermostat:

```
20:27:43.224  os = 2   (COOLING)  <- cycle start
20:27:43.584  fs = 1   (fan on,  +360 ms)
20:28:22.220  val = 21.667 C (71.0 F)
20:39:43.232  val = 21.111 C (70.0 F)
20:46:10.373  val = 20.833 C (69.5 F)
20:54:43.256  os = 0   (IDLE)     <- cycle end, 27 min 00 s
20:54:43.342  fs = 0   (fan off, +86 ms)
20:54:43.396  val = 20.556 C (69.0 F)  == the cool setpoint, exactly
```

The cycle terminates at the precise moment measured temperature reaches setpoint, and the fan trails the compressor by under 400 ms on both edges.

**3. It is a push signal, not a poll artifact.** These arrive as PubNub partial deltas roughly **70 ms** after the cloud-side timestamp (`plctx.ts`), each message carrying only the one changed field. The 300 s `DataUpdateCoordinator` refresh is separately visible in the log and does not coincide with either edge. So `os` is a pure edge-event stream — with this fix `hvac_action` becomes accurate to well under a second instead of being a constant.

## Impact

Anyone using `hvac_action` for runtime, duty-cycle, or cycle-count history currently gets a flat line. On the system above this meant three thermostats produced no usable equipment data at all across the full retention window.

## Testing

- One-line change; `hvac_mode` (line 194) deliberately untouched.
- Behaviour confirmed against the raw device payload as above.
- Happy to add a unit test for the enum-collision case if you'd like one in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HVAC status reporting by using the device’s current operating state.
  * Preserved the existing idle status fallback when no active operation is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->